### PR TITLE
Fix bug that produces invalid XML plist

### DIFF
--- a/classes/CFPropertyList/CFType.php
+++ b/classes/CFPropertyList/CFType.php
@@ -70,12 +70,8 @@ abstract class CFType {
    */
   public function toXML(DOMDocument $doc, $nodeName) {
     $node = $doc->createElement($nodeName);
-
-    if($this->value !== '') {
-      $text = $doc->createTextNode($this->value);
-      $node->appendChild($text);
-    }
-
+    $text = $doc->createTextNode($this->value);
+    $node->appendChild($text);
     return $node;
   }
 


### PR DESCRIPTION
If a CFNumber(0) is serialized as XML, it produces an invalid XML node (<integer/>) which triggers a parse error in Apple's code. This code fixes this issue.
