### PR TITLE
Fixed reading binary plists with objectRefSize > 2

### DIFF
--- a/classes/CFPropertyList/CFBinaryPropertyList.php
+++ b/classes/CFPropertyList/CFBinaryPropertyList.php
@@ -584,13 +584,12 @@ abstract class CFBinaryPropertyList {
   /**
    * „pack” a value (i.e. write the binary representation as big endian to a string) with the specified size
    * @param integer $nbytes The number of bytes to pack
-   * @param integer $int the integer value to pack
+   * @param integer $int The integer value to pack
    * @return string The packed value as string
    */
   public static function packItWithSize($nbytes,$int) {
     $formats = Array("C", "n", "N", "N");
     $format = $formats[$nbytes-1];
-    $ret = '';
 
     if($nbytes == 3) return substr(pack($format, $int), -3);
     return pack($format, $int);


### PR DESCRIPTION
Trying to read a rather large binary plist (1MB+) resulted in infinite recursion, causing a fatal error / memory exhaustion. The problem was that readBinaryArray() and readBinaryDict() could only handle objectRefSizes of 1 or 2, but the large file used an objectRefSize of 4.

I've fixed the problem by extracting this logic to a new method, similar to (and in the same style of) packItWithSize(), and handling the case of objectRefSize 4 (and 3, for what it's worth) properly.

As far as I could see (haven't tested this), writing files with an objectRefSize of 4 was already handled properly by packItWithSize().
