### PR TITLE
Consistently handle XML errors by throwing exception

### DIFF
--- a/tests/ParseXMLTest.php
+++ b/tests/ParseXMLTest.php
@@ -89,9 +89,7 @@ class ParseXMLTest extends \PHPUnit_Framework_TestCase {
       $plist->parse('lalala');
     }
     catch(\DOMException $e) {
-      $catched = true;
-    }
-    catch(\PHPUnit_Framework_Error $e) {
+      $this->assertNotEmpty($e->getMessage());
       $catched = true;
     }
 
@@ -107,7 +105,8 @@ class ParseXMLTest extends \PHPUnit_Framework_TestCase {
     catch(PListException $e) {
       return;
     }
-    catch(\PHPUnit_Framework_Error $e) {
+    catch(\DOMException $e) {
+      $this->assertNotEmpty($e->getMessage());
       return;
     }
 


### PR DESCRIPTION
And information about the error as as the exception message
Prevents PHP warnings about XML issues, and returns the system to its old state once done.
