### PR TITLE
Reverse the symmetry issue

### DIFF
--- a/src/CFPropertyList/CFDate.php
+++ b/src/CFPropertyList/CFDate.php
@@ -142,13 +142,4 @@ class CFDate extends CFType
         }
         return gmmktime($matches[4], $matches[5], $matches[6], $matches[2], $matches[3], $matches[1]);
     }
-
-    public function toArray()
-    {
-        if (class_exists('DateTime')) {
-            return new DateTime('@'.intval($this->getValue()), new DateTimeZone('UTC'));
-        }
-
-        return parent::getValue();
-    }
 }

--- a/src/CFPropertyList/CFTypeDetector.php
+++ b/src/CFPropertyList/CFTypeDetector.php
@@ -155,7 +155,7 @@ class CFTypeDetector
 
             case is_object($value):
                 // DateTime should be CFDate
-                if (class_exists(DateTime::class) && $value instanceof DateTime) {
+                if ($value instanceof DateTime) {
                     return new CFDate($value->getTimestamp());
                 }
 


### PR DESCRIPTION
DateTime class always exists for php 5.6 or later,  then no need to test its availability

See #54