### PR TITLE
Test on PHP 7.3 and 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4snapshot
   - nightly
 
 allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 script:
   - vendor/bin/phpunit tests/unit
   - vendor/bin/phpunit tests/functional
-  #- vendor/bin/phpcs --standard=PSR2 -n src/ tests/
+  - vendor/bin/phpcs --standard=PSR2 -n src/ tests/
   - php examples/example-create-01.php
   - php examples/example-create-02.php
   - php examples/example-create-03.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
 script:
   - vendor/bin/phpunit tests/unit
   - vendor/bin/phpunit tests/functional
-  - vendor/bin/phpcs --standard=PSR2 -n src/ tests/
+  #- vendor/bin/phpcs --standard=PSR2 -n src/ tests/
   - php examples/example-create-01.php
   - php examples/example-create-02.php
   - php examples/example-create-03.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ php:
   - 7.4snapshot
   - nightly
 
-allow_failures:
-  - php: nightly
+matrix:
+  allow_failures:
+    - php: nightly
 
 before_script:
   - composer install --no-interaction

--- a/src/CFPropertyList/CFBinaryPropertyList.php
+++ b/src/CFPropertyList/CFBinaryPropertyList.php
@@ -941,7 +941,7 @@ abstract class CFBinaryPropertyList
     protected static function binaryStrlen($val)
     {
         for ($i=0; $i<strlen($val); ++$i) {
-            if (ord($val{$i}) >= 128) {
+            if (ord($val[$i]) >= 128) {
                 $val = self::convertCharset($val, 'UTF-8', 'UTF-16BE');
                 return strlen($val);
             }

--- a/src/CFPropertyList/CFBinaryPropertyList.php
+++ b/src/CFPropertyList/CFBinaryPropertyList.php
@@ -965,7 +965,7 @@ abstract class CFBinaryPropertyList
             $utf16 = false;
 
             for ($i=0; $i<strlen($val); ++$i) {
-                if (ord($val{$i}) >= 128) {
+                if (ord($val[$i]) >= 128) {
                     $utf16 = true;
                     break;
                 }

--- a/src/CFPropertyList/CFBinaryPropertyList.php
+++ b/src/CFPropertyList/CFBinaryPropertyList.php
@@ -940,6 +940,7 @@ abstract class CFBinaryPropertyList
    */
     protected static function binaryStrlen($val)
     {
+        $val = (string) $val;
         for ($i=0; $i<strlen($val); ++$i) {
             if (ord($val[$i]) >= 128) {
                 $val = self::convertCharset($val, 'UTF-8', 'UTF-16BE');

--- a/src/CFPropertyList/CFPropertyList.php
+++ b/src/CFPropertyList/CFPropertyList.php
@@ -412,9 +412,8 @@ class CFPropertyList extends CFBinaryPropertyList implements Iterator
         // Dictionaries need a key
             if ($parent instanceof CFDictionary) {
                 $parent->add($key, $value);
-            }
-            // others don't
-            else {
+            } else {
+                // others don't
                 $parent->add($value);
             }
         }

--- a/src/CFPropertyList/CFPropertyList.php
+++ b/src/CFPropertyList/CFPropertyList.php
@@ -412,7 +412,8 @@ class CFPropertyList extends CFBinaryPropertyList implements Iterator
         // Dictionaries need a key
             if ($parent instanceof CFDictionary) {
                 $parent->add($key, $value);
-            } // others don't
+            }
+            // others don't
             else {
                 $parent->add($value);
             }


### PR DESCRIPTION
There are failures when running on PHP 7.4, curly braces array access is deprecated.

Would be good to have a new point release when this is fixed.