### PR TITLE
Locale insensitive float format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "ext-dom": "*",
-        "ext-libxml": "*"
+        "ext-libxml": "*",
+        "ext-intl": "*"
     },
     "authors": [
         {

--- a/src/CFPropertyList/CFNumber.php
+++ b/src/CFPropertyList/CFNumber.php
@@ -45,8 +45,7 @@
 namespace CFPropertyList;
 
 use \DOMDocument;
-use \Iterator;
-use \ArrayAccess;
+use \NumberFormatter;
 
 /**
  * Number Type  of CFPropertyList
@@ -68,7 +67,13 @@ class CFNumber extends CFType
             $this->value = intval($this->value);
             $ret = 'integer';
         }
-        return parent::toXML($doc, $ret);
+        $formatter = new NumberFormatter('en_US', NumberFormatter::DECIMAL);
+        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 10);
+        $formatter->setAttribute(NumberFormatter::GROUPING_USED, false);
+        $text = $doc->createTextNode($formatter->format($this->value));
+        $node = $doc->createElement($ret);
+        $node->appendChild($text);
+        return $node;
     }
 
   /**


### PR DESCRIPTION
Floats must be represented in XML using the American format.

fix #67 