### PR TITLE
PHP 8.1 compatibility

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest]
+        php: ["7.4", "8.0", "8.1"]
+        dependency-version: [prefer-lowest, prefer-stable]
+
+    name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, libxml
+          coverage: none
+          tools: composer
+
+      - name: Install dependencies
+        run: composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+      - name: Execute tests
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Makefile
 .DS_Store
 .vscode
 node-modules
+/.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "homepage": "https://github.com/TECLIB/CFPropertyList",
     "license": "MIT",
     "require": {
-        "php": ">=5.6"
+        "php": "^7.4 || ^8.0",
+        "ext-dom": "*",
+        "ext-libxml": "*"
     },
     "authors": [
         {
@@ -38,7 +40,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0 || ^6.0 ||^7.0 ||^8.5",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -42,5 +42,10 @@
     "require-dev": {
         "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2"
+    },
+    "scripts": {
+        "test": [
+            "vendor/bin/phpunit"
+        ]
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.2/phpunit.xsd"
-  bootstrap="tests/bootstrap.php"
-  colors="true"
->
-
-</phpunit>

--- a/src/CFPropertyList/CFArray.php
+++ b/src/CFPropertyList/CFArray.php
@@ -177,7 +177,7 @@ class CFArray extends CFType implements Iterator, ArrayAccess
    * @return void
    * @uses $iteratorPosition set to 0
    */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorPosition = 0;
     }
@@ -185,9 +185,10 @@ class CFArray extends CFType implements Iterator, ArrayAccess
   /**
    * Get Iterator's current {@link CFType} identified by {@link $iteratorPosition}
    * @link http://php.net/manual/en/iterator.current.php
-   * @return CFType current Item
+   * @return mixed current Item
    * @uses $iteratorPosition identify current key
    */
+   #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->value[$this->iteratorPosition];
@@ -196,9 +197,10 @@ class CFArray extends CFType implements Iterator, ArrayAccess
   /**
    * Get Iterator's current key identified by {@link $iteratorPosition}
    * @link http://php.net/manual/en/iterator.key.php
-   * @return string key of the current Item
+   * @return mixed key of the current Item: mixed
    * @uses $iteratorPosition identify current key
    */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorPosition;
@@ -210,7 +212,7 @@ class CFArray extends CFType implements Iterator, ArrayAccess
    * @return void
    * @uses $iteratorPosition increment by 1
    */
-    public function next()
+    public function next(): void
     {
         $this->iteratorPosition++;
     }
@@ -218,11 +220,11 @@ class CFArray extends CFType implements Iterator, ArrayAccess
   /**
    * Test if {@link $iteratorPosition} addresses a valid element of {@link $value}
    * @link http://php.net/manual/en/iterator.valid.php
-   * @return boolean true if current position is valid, false else
+   * @return bool true if current position is valid, false else
    * @uses $iteratorPosition test if within {@link $iteratorKeys}
    * @uses $iteratorPosition test if within {@link $value}
    */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->value[$this->iteratorPosition]);
     }
@@ -233,53 +235,54 @@ class CFArray extends CFType implements Iterator, ArrayAccess
 
   /**
    * Determine if the array's key exists
-   * @param string $key the key to check
+   * @param string $offset the key to check
    * @return bool true if the offset exists, false if not
    * @link http://php.net/manual/en/arrayaccess.offsetexists.php
    * @uses $value to check if $key exists
    * @author Sean Coates <sean@php.net>
    */
-    public function offsetExists($key)
+    public function offsetExists($offset): bool
     {
-        return isset($this->value[$key]);
+        return isset($this->value[$offset]);
     }
 
   /**
    * Fetch a specific key from the CFArray
-   * @param string $key the key to check
+   * @param mixed $offset the key to check
    * @return mixed the value associated with the key; null if the key is not found
    * @link http://php.net/manual/en/arrayaccess.offsetget.php
    * @uses get() to get the key's value
    * @author Sean Coates <sean@php.net>
    */
-    public function offsetGet($key)
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
     {
-        return $this->get($key);
+        return $this->get($offset);
     }
 
   /**
    * Set a value in the array
-   * @param string $key the key to set
-   * @param string $value the value to set
+   * @param mixed $offset the key to set
+   * @param mixed $value the value to set
    * @return void
    * @link http://php.net/manual/en/arrayaccess.offsetset.php
    * @uses setValue() to set the key's new value
    * @author Sean Coates <sean@php.net>
    */
-    public function offsetSet($key, $value)
+    public function offsetSet($offset, $value): void
     {
-        return $this->setValue($value);
+        $this->setValue($value);
     }
 
   /**
    * Unsets a value in the array
    * <b>Note:</b> this dummy does nothing
-   * @param string $key the key to set
+   * @param mixed $offset the key to set
    * @return void
    * @link http://php.net/manual/en/arrayaccess.offsetunset.php
    * @author Sean Coates <sean@php.net>
    */
-    public function offsetUnset($key)
+    public function offsetUnset($offset): void
     {
     }
 }

--- a/src/CFPropertyList/CFDictionary.php
+++ b/src/CFPropertyList/CFDictionary.php
@@ -181,7 +181,7 @@ class CFDictionary extends CFType implements Iterator
     * @uses $iteratorPosition set to 0
     * @uses $iteratorKeys store keys of {@link $value}
     */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorPosition = 0;
         $this->iteratorKeys = array_keys($this->value);
@@ -189,10 +189,11 @@ class CFDictionary extends CFType implements Iterator
    /**
     * Get Iterator's current {@link CFType} identified by {@link $iteratorPosition}
     * @link http://php.net/manual/en/iterator.current.php
-    * @return CFType current Item
+    * @return mixed current Item
     * @uses $iteratorPosition identify current key
     * @uses $iteratorKeys identify current value
     */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->value[$this->iteratorKeys[$this->iteratorPosition]];
@@ -200,10 +201,11 @@ class CFDictionary extends CFType implements Iterator
    /**
     * Get Iterator's current key identified by {@link $iteratorPosition}
     * @link http://php.net/manual/en/iterator.key.php
-    * @return string key of the current Item
+    * @return mixed key of the current Item
     * @uses $iteratorPosition identify current key
     * @uses $iteratorKeys identify current value
     */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorKeys[$this->iteratorPosition];
@@ -214,18 +216,18 @@ class CFDictionary extends CFType implements Iterator
     * @return void
     * @uses $iteratorPosition increment by 1
     */
-    public function next()
+    public function next(): void
     {
         $this->iteratorPosition++;
     }
    /**
     * Test if {@link $iteratorPosition} addresses a valid element of {@link $value}
     * @link http://php.net/manual/en/iterator.valid.php
-    * @return boolean true if current position is valid, false else
+    * @return bool true if current position is valid, false else
     * @uses $iteratorPosition test if within {@link $iteratorKeys}
     * @uses $iteratorPosition test if within {@link $value}
     */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->iteratorKeys[$this->iteratorPosition]) && isset($this->value[$this->iteratorKeys[$this->iteratorPosition]]);
     }

--- a/src/CFPropertyList/CFPropertyList.php
+++ b/src/CFPropertyList/CFPropertyList.php
@@ -667,7 +667,7 @@ class CFPropertyList extends CFBinaryPropertyList implements Iterator
    * @uses $iteratorPosition set to 0
    * @uses $iteratorKeys store keys of {@link $value}
    */
-    public function rewind()
+    public function rewind(): void
     {
         $this->iteratorPosition = 0;
         $this->iteratorKeys = array_keys($this->value);
@@ -676,10 +676,11 @@ class CFPropertyList extends CFBinaryPropertyList implements Iterator
   /**
    * Get Iterator's current {@link CFType} identified by {@link $iteratorPosition}
    * @link http://php.net/manual/en/iterator.current.php
-   * @return CFType current Item
+   * @return mixed current Item
    * @uses $iteratorPosition identify current key
    * @uses $iteratorKeys identify current value
    */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->value[$this->iteratorKeys[$this->iteratorPosition]];
@@ -688,10 +689,11 @@ class CFPropertyList extends CFBinaryPropertyList implements Iterator
   /**
    * Get Iterator's current key identified by {@link $iteratorPosition}
    * @link http://php.net/manual/en/iterator.key.php
-   * @return string key of the current Item
+   * @return mixed key of the current Item
    * @uses $iteratorPosition identify current key
    * @uses $iteratorKeys identify current value
    */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->iteratorKeys[$this->iteratorPosition];
@@ -703,7 +705,7 @@ class CFPropertyList extends CFBinaryPropertyList implements Iterator
    * @return void
    * @uses $iteratorPosition increment by 1
    */
-    public function next()
+    public function next(): void
     {
         $this->iteratorPosition++;
     }
@@ -715,7 +717,7 @@ class CFPropertyList extends CFBinaryPropertyList implements Iterator
    * @uses $iteratorPosition test if within {@link $iteratorKeys}
    * @uses $iteratorPosition test if within {@link $value}
    */
-    public function valid()
+    public function valid(): bool
     {
         return isset($this->iteratorKeys[$this->iteratorPosition]) && isset($this->value[$this->iteratorKeys[$this->iteratorPosition]]);
     }

--- a/tests/functional/BinaryParseTest.php
+++ b/tests/functional/BinaryParseTest.php
@@ -104,11 +104,10 @@ class BinaryParseTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($vals['birth-date'], 412035803);
     }
 
-  /**
-   * @expectedException CFPropertyList\PListException
-   */
     public function testEmptyString()
     {
+        $this->expectException(PListException::class);
+
         $plist = new CFPropertyList();
         $plist->parseBinary('');
     }

--- a/tests/functional/ParseXMLTest.php
+++ b/tests/functional/ParseXMLTest.php
@@ -103,11 +103,10 @@ class ParseXMLTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($vals['birth-date'], 412035803);
     }
 
-  /**
-   * @expectedException CFPropertyList\IOException
-   */
     public function testEmptyString()
     {
+        $this->expectException(IOException::class);
+
         $plist = new CFPropertyList();
         $plist->parse('');
     }


### PR DESCRIPTION
As discussed in #69, this PR adds missing type hints to `CFArray`, `CFPropertyList`, and `CFDictionary` to remove deprecation warnings in PHP 8.1.

## Changes

- Require a minimum PHP version of 7.4
- Properly set up PHPUnit
  - Bumped minimum required PHPUnit version to `^9.0`
  - Removed old (and empty) `phpunit.xml.dist` and replaced it with a working `phpunit.xml`. This allows us to simply run `vendor/bin/phpunit` without specifying a folder.
  - Added a `composer test` script as a convenience. This also gets used during CI.
  - Replaced deprecated `@expectedException` annotation with `$this->expectException()`
- Updated method signatures to remove deprecation warning in PHP 8.1
  - `CFArray` -- Updated signatures for methods of `ArrayAccess` and `Iterator` interfaces
  - `CFDictionary` -- Updated signatures for methods of `Iterator` interface
  - `CFPropertyList` -- Updated signatures for methods of `Iterator` interface
  - Added `#[\ReturnTypeWillChange]` attribute where `mixed` type would be expected to keep BC for PHP 7.4 for now

I also decided to add the Github Action in this PR since it was a bit of a pain doing this on the old `develop` branch with all the old PHP versions still supported. I hope this is ok. The workflow will run the test suite against PHP `7.4`, `8.0`, and `8.1`. Since the `convertDeprecationsToExceptions` option in PHPUnit is set to `true`, this would fail if there were any deprecation notices left.