### PR TITLE
Fix PHP8.2 str_split function returns empty arrays for empty strings

### DIFF
--- a/src/CFPropertyList/CFBinaryPropertyList.php
+++ b/src/CFPropertyList/CFBinaryPropertyList.php
@@ -738,7 +738,7 @@ abstract class CFBinaryPropertyList
         $format = $formats[$nbytes-1];
 
         if ($nbytes == 3) {
-            $buff = "\0" . implode("\0", str_split($buff, 3));
+            $buff = "\0" . implode("\0", mb_str_split($buff, 3));
         }
         return unpack($format, $buff);
     }


### PR DESCRIPTION
### Changes description

In PHP 8.2, the str_split function will returns empty arrays for empty strings.
We can use mb_str_split() instead

### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [ ] Docs have been added/updated

### References

[<!-- issues related (for reference or to be closed) and/or links of discuss -->](https://php.watch/versions/8.2/str_split-empty-string-empty-array)

Closes #N/A